### PR TITLE
Fixes follower and following count state update

### DIFF
--- a/components/FollowChangeBtn.tsx
+++ b/components/FollowChangeBtn.tsx
@@ -49,14 +49,30 @@ const FollowBtn: React.FC<FollowBtnProps> = ({ followUser }) => {
 interface FollowChangeBtnProps {
   followingStatus: boolean | null
   setFollowingStatus: (status: boolean) => void
+  followingCountStat: number
+  setFollowingCountStat: (amount: number) => void
+  followerCountStat: number
+  setFollowerCountStat: (amount: number) => void
   username: string
 }
 
 const FollowChangeBtn: React.FC<FollowChangeBtnProps> = ({
   followingStatus,
   setFollowingStatus,
+  followingCountStat,
+  setFollowingCountStat,
+  followerCountStat,
+  setFollowerCountStat,
   username,
 }) => {
+  console.log('followers:', followerCountStat)
+  const [currentFollowingCount, setCurrentFollowingCount] = React.useState(
+    followingCountStat
+  )
+  const [currentFollowerCount, setCurrentFollowerCount] = React.useState(
+    followerCountStat
+  )
+  console.log('currentFollowerCount', currentFollowerCount)
   const variables: UserFollowChangeVars = {
     username: username,
   }
@@ -75,6 +91,21 @@ const FollowChangeBtn: React.FC<FollowChangeBtnProps> = ({
         const { data }: { data?: UserFollowChangeReturnType } = res || {}
         if (data && data.result.user) {
           setFollowingStatus(data.result.user.areFollowing)
+
+          //if the current *logged-in* user is on their OWN profile, increment their following count
+          if (
+            currentUserInfo &&
+            window.location.pathname.includes(currentUserInfo?.me.username)
+          ) {
+            const newFollowingCount = currentFollowingCount + 1
+            setFollowingCountStat(newFollowingCount)
+            setCurrentFollowingCount(newFollowingCount)
+            //if the user *being unfollowed* from their own profile, increment their follower count
+          } else if (window.location.pathname.includes(username)) {
+            const newFollowerCount = followerCountStat + 1
+            setFollowerCountStat(newFollowerCount)
+            setCurrentFollowerCount(newFollowerCount)
+          }
         }
       })
   }
@@ -94,6 +125,21 @@ const FollowChangeBtn: React.FC<FollowChangeBtnProps> = ({
         const { data }: { data?: UserFollowChangeReturnType } = res || {}
         if (data && data.result.user) {
           setFollowingStatus(data.result.user.areFollowing)
+
+          //if the current *logged-in* user is on their OWN profile, decrement their following count
+          if (
+            currentUserInfo &&
+            window.location.pathname.includes(currentUserInfo?.me.username)
+          ) {
+            const newFollowingCount = currentFollowingCount - 1
+            setFollowingCountStat(newFollowingCount)
+            setCurrentFollowingCount(newFollowingCount)
+            //if the user *being unfollowed* from their own profile, decrement their follower count
+          } else if (window.location.pathname.includes(username)) {
+            const newFollowerCount = followerCountStat - 1
+            setFollowerCountStat(newFollowerCount)
+            setCurrentFollowerCount(newFollowerCount)
+          }
         }
       })
   }

--- a/components/StatView.tsx
+++ b/components/StatView.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+type StatViewProps = {
+  name: string
+  count: number
+  onClick: () => void
+}
+
+const StatView: React.FC<StatViewProps> = ({ name, count, onClick }) => {
+  const [currentCount, setCurrentCount] = React.useState(count)
+  return (
+    <li className="text-center w-1/3" key={name}>
+      <button onClick={onClick}>
+        <span className="block text-gray-900 font-bold">{currentCount}</span>
+        {name}
+      </button>
+    </li>
+  )
+}
+
+export default StatView

--- a/components/modalviews/UserRelList.tsx
+++ b/components/modalviews/UserRelList.tsx
@@ -16,12 +16,20 @@ type UserRelListProps = {
   username: string
   relationship: 'following' | 'followers'
   inModal?: boolean
+  followingCountStat: number
+  setFollowingCountStat: (amount: number) => void
+  followerCountStat: number
+  setFollowerCountStat: (amount: number) => void
 }
 
 const UserRelList: React.FC<UserRelListProps> = ({
   username,
   relationship,
   inModal,
+  followingCountStat,
+  setFollowingCountStat,
+  followerCountStat,
+  setFollowerCountStat,
 }) => {
   const UsersFollowRelVars: FollowRelListByUsernameVars = {
     username: username,
@@ -110,6 +118,10 @@ const UserRelList: React.FC<UserRelListProps> = ({
                         setFollowingStatus={(status: boolean) => {
                           setFollowingStatus(edge.node.username, status)
                         }}
+                        followingCountStat={followingCountStat}
+                        setFollowingCountStat={setFollowingCountStat}
+                        followerCountStat={followerCountStat}
+                        setFollowerCountStat={setFollowerCountStat}
                         username={edge.node.username}
                       />
                     ) : (

--- a/pages/[username].tsx
+++ b/pages/[username].tsx
@@ -24,6 +24,7 @@ import SettingsBtn from 'components/SettingsBtn'
 import FollowChangeBtn from 'components/FollowChangeBtn'
 import UserRelList from 'components/modalviews/UserRelList'
 import UpdateProfileImage from 'components/modalviews/UpdateProfileImage'
+import StatView from 'components/StatView'
 import { profile } from 'console'
 
 interface UserPageProps {
@@ -54,6 +55,10 @@ const UserPage: NextPage<UserPageProps> = ({ userInfo }) => {
           username={username}
           relationship="followers"
           inModal={true}
+          followingCountStat={followingCountStat}
+          setFollowingCountStat={setFollowingCountStat}
+          followerCountStat={followerCountStat}
+          setFollowerCountStat={setFollowerCountStat}
         />
       )
   }
@@ -66,6 +71,10 @@ const UserPage: NextPage<UserPageProps> = ({ userInfo }) => {
           username={username}
           relationship="following"
           inModal={true}
+          followingCountStat={followingCountStat}
+          setFollowingCountStat={setFollowingCountStat}
+          followerCountStat={followerCountStat}
+          setFollowerCountStat={setFollowerCountStat}
         />
       )
   }
@@ -105,19 +114,13 @@ const UserPage: NextPage<UserPageProps> = ({ userInfo }) => {
     followerCount
   )
 
-  const [stats, setStats] = React.useState([
-    { name: 'recipes', count: recipeCount, onClick: () => {} },
-    {
-      name: 'followers',
-      count: followerCountState,
-      onClick: openFollowers,
-    },
-    {
-      name: 'following',
-      count: followingCount,
-      onClick: openFollowing,
-    },
-  ])
+  const [recipeCountStat, setRecipeCountStat] = React.useState(recipeCount)
+  const [followerCountStat, setFollowerCountStat] = React.useState(
+    followerCountState
+  )
+  const [followingCountStat, setFollowingCountStat] = React.useState(
+    followingCount
+  )
 
   const [followingStatus, setFollowingStatus] = React.useState(areFollowing)
 
@@ -151,19 +154,9 @@ const UserPage: NextPage<UserPageProps> = ({ userInfo }) => {
     setCurrProfileImageUrl(profileImageUrl)
     console.log('followerCount', followerCount)
     setFollowerCountState(followerCount)
-    setStats([
-      { name: 'recipes', count: recipeCount, onClick: () => {} },
-      {
-        name: 'followers',
-        count: followerCount,
-        onClick: openFollowers,
-      },
-      {
-        name: 'following',
-        count: followingCount,
-        onClick: openFollowing,
-      },
-    ])
+    setRecipeCountStat(recipeCount)
+    setFollowerCountStat(followerCount)
+    setFollowingCountStat(followingCount)
   }
   React.useEffect(() => {
     setFollowingStatus(areFollowing)
@@ -233,25 +226,40 @@ const UserPage: NextPage<UserPageProps> = ({ userInfo }) => {
                   setFollowingStatus={(status: boolean) =>
                     setFollowingStatus(status)
                   }
+                  followingCountStat={followingCountStat}
+                  setFollowingCountStat={setFollowingCountStat}
+                  followerCountStat={followerCountStat}
+                  setFollowerCountStat={setFollowerCountStat}
                   username={username}
                 />
               )}
             </div>
           </header>
           <ul className="flex flex-row text-gray-500 font-semibold text-sm leading-tight border-t border-b py-3">
-            {stats.map((stat) => {
-              const { name, count, onClick } = stat
-              return (
-                <li className="text-center w-1/3" key={name}>
-                  <button onClick={onClick}>
-                    <span className="block text-gray-900 font-bold">
-                      {count}
-                    </span>
-                    {name}
-                  </button>
-                </li>
-              )
-            })}
+            <li className="text-center w-1/3" key="recipes">
+              <button>
+                <span className="block text-gray-900 font-bold">
+                  {recipeCountStat}
+                </span>
+                recipes
+              </button>
+            </li>
+            <li className="text-center w-1/3" key="followers">
+              <button onClick={openFollowers}>
+                <span className="block text-gray-900 font-bold">
+                  {followerCountStat}
+                </span>
+                followers
+              </button>
+            </li>
+            <li className="text-center w-1/3" key="following">
+              <button onClick={openFollowing}>
+                <span className="block text-gray-900 font-bold">
+                  {followingCountStat}
+                </span>
+                following
+              </button>
+            </li>
           </ul>
           <InfiniteScroll
             QUERY={ALL_USER_RECIPES_BY_USERNAME}


### PR DESCRIPTION
When a user would hit the follow/unfollow button while on their own profile, the following count would not update state to reflect the change in the number of users they are following.

Also, when a user would hit the follow/unfollow button while on another user's profile, the follower count for that user would not update state to reflect the change in the number of users that are following them.

Both cases now work properly based on my tests.